### PR TITLE
ci: use GitHub App token for SPM publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,24 @@ jobs:
           echo "FRAMEWORK_NAME=WoosmapGeofencing" >> $GITHUB_ENV
           echo "NEW_VERSION=${{ github.event.client_payload.v }}" >> $GITHUB_ENV
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Download artifact zip
         run: |
-          curl -L -H "Authorization: token ${{ secrets.WOOSMAP_GITHUB_TOKEN }}" \
+          curl -L -H "Authorization: token $GH_TOKEN" \
             -o $RUNNER_TEMP/artifact.zip \
             https://api.github.com/repos/Woosmap/geofencing-enterprise-ios-sdk/actions/artifacts/${{ github.event.client_payload.artifact_id }}/zip
 
-          curl -L -H "Authorization: token ${{ secrets.WOOSMAP_GITHUB_TOKEN }}" \
+          curl -L -H "Authorization: token $GH_TOKEN" \
               -o $RUNNER_TEMP/$FRAMEWORK_NAME.xcframework.zip \
               https://api.github.com/repos/Woosmap/geofencing-enterprise-ios-sdk/actions/artifacts/${{ github.event.client_payload.sdk_artifact_id }}/zip
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Unzip artifact and restructure
         run: |
@@ -48,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Update Package.swift
         run: |
@@ -66,25 +76,18 @@ jobs:
           sed -E -i '' '1s/.*/\{\n\t"'$NEW_VERSION'\" : \"'${DISTRIBUTION_REPO////\\/}'\/releases\/download\/'$NEW_VERSION'\/${{ env.FRAMEWORK_NAME }}.xcframework.zip?raw=true\",/' $FRAMEWORK_NAME.json
 
 
-      - name: Commit and push changes (optional)
-        if: github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
+      - name: Commit and push changes
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add Package.swift
-          git add $FRAMEWORK_NAME.json
-          git commit -m "Update checksum and version in Package.swift and $FRAMEWORK_NAME.json"
-          git push
+          git config user.name  "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git add Package.swift "${FRAMEWORK_NAME}.json"
+          git commit -m "[AUTO] Update checksum and version for ${NEW_VERSION}"
+          git push origin HEAD:${{ github.event.repository.default_branch }}
 
       - name: Create Git tag
-        if: github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git tag ${VERSION}
-          git push origin ${VERSION}
-        env:
-          VERSION: ${{ github.event.client_payload.v }}
+          git tag ${NEW_VERSION}
+          git push origin ${NEW_VERSION}
 
       
       - name: Check
@@ -99,4 +102,3 @@ jobs:
           files: ${{ runner.temp }}/${{ env.FRAMEWORK_NAME }}.xcframework.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
               -o $RUNNER_TEMP/$FRAMEWORK_NAME.xcframework.zip \
               https://api.github.com/repos/Woosmap/geofencing-enterprise-ios-sdk/actions/artifacts/${{ github.event.client_payload.sdk_artifact_id }}/zip
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.WOOSMAP_GITHUB_TOKEN }}
 
       - name: Unzip artifact and restructure
         run: |


### PR DESCRIPTION
## Issue
#2

## Describe your changes
Switch the SPM publish workflow (`.github/workflows/publish.yml`) to authenticate via a GitHub App (release-bot) instead of the personal `WOOSMAP_GITHUB_TOKEN` secret.

- Generate an App token with `actions/create-github-app-token@v1` using `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`.
- Use the App token for artifact downloads, repo checkout, commit, push, and tag.
- Commit as `release-bot[bot]` with a standardized `[AUTO] Update checksum and version for <version>` message.
- Remove the `github.ref == default_branch` guards and push/tag explicitly to the default branch so the workflow is not silently skipped when triggered from a `repository_dispatch` event.

## How to test
1. Ensure the `release-bot` GitHub App is installed on this repo with contents write permission.
2. Confirm `vars.RELEASE_BOT_APP_ID` and `secrets.RELEASE_BOT_PRIVATE_KEY` are configured.
3. Trigger the `publish-spm` workflow via `repository_dispatch` from `Woosmap/geofencing-enterprise-ios-sdk` with a test `v` and artifact IDs.
4. Verify the workflow:
   - Downloads both artifacts successfully using the App token.
   - Updates `Package.swift` and `WoosmapGeofencing.json` on the default branch.
   - Commits as `release-bot[bot]` and pushes the new tag.
   - Creates the GitHub Release with the xcframework zip attached.
   
   ### Command line execution (This executes the workflow  only from the default branch)
```
gh api repos/Woosmap/geofencing-ios-sdk-spm-release/dispatches \
  --method POST \
  --input - <<EOF
{
  "event_type": "spm",
  "client_payload": {
    "ref": "refs/heads/SDK4.0",
    "v": "4.5.4-alpha1",
    "artifact_id": "6548019925",
    "sdk_artifact_id": "6548019617"
  }
}
EOF
```

## Checklist:
- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

> Ops change required: the `release-bot` GitHub App must be installed on this repo and the `RELEASE_BOT_APP_ID` variable + `RELEASE_BOT_PRIVATE_KEY` secret must be configured before merging.

### Documentation
N/A

### Libs/SDKs
N/A